### PR TITLE
Add links to Products in a documentation header dropdown menu

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -59,6 +59,7 @@ export default defineClientConfig({
             // Products
             productsList: ['Cloudlinux', 'Imunify', 'TuxCare'],
             productsTitle: 'Products',
+            productsURLs: ['https://docs.cloudlinux.com', 'https://docs.imunify360.com', 'https://docs.tuxcare.com'],
 
             //social links for footer
             social,

--- a/docs/.vuepress/theme/header/HeaderProducts.vue
+++ b/docs/.vuepress/theme/header/HeaderProducts.vue
@@ -3,14 +3,14 @@
     <div ref="menu" class="dropdown">
      <teleport v-if="isMobileWidth" to="body">
        <div v-if="openedMenu" class="dropdown-wrapper">
-         <p class="dropdown-content__paragraph" v-for="product in productsList" :key="product">
-           <a class="dropdown-content__link" href="#">{{ product }}</a>
-         </p>
+          <p class="dropdown-content__paragraph" v-for="(product, index) in productsList" :key="product">
+            <a class="dropdown-content__link" :href="productsURLs[index]">{{ product }}</a>
+          </p>
        </div>
      </teleport>
       <div v-if="openedMenu && !isMobileWidth" class="dropdown-wrapper">
-        <p class="dropdown-content__paragraph" v-for="product in productsList" :key="product">
-          <a class="dropdown-content__link" href="#">{{ product }}</a>
+        <p class="dropdown-content__paragraph" v-for="(product, index) in productsList" :key="product">
+          <a class="dropdown-content__link" :href="productsURLs[index]">{{ product }}</a>
         </p>
       </div>
       <div @click="openedMenu = !openedMenu" class="header-products-container">
@@ -33,7 +33,7 @@ defineProps({
     type: Boolean,
   },
 })
-const {productsTitle, arrowDownIcon, productsList} = inject('themeConfig');
+const {productsTitle, arrowDownIcon, productsList, productsURLs} = inject('themeConfig');
 
 const openedMenu = ref(false)
 const menu = ref(null)


### PR DESCRIPTION
I added an array of urls to `themeConfig` in `client.ts`
I edited the `v-for` loops in `HeaderProducts.vue` to add hypertext links to each header dropdown menu item.