### PR TITLE
Removed reference to reCaptcha as it is not being used anymore.

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1408,7 +1408,6 @@ Click <span class="notranslate">_Save changes_</span> button on the bottom of th
   * KeyCDN
   * Dartspeed.com
   * QUIC.cloud CDN
-* <span class="notranslate">_Google reCAPTCHA configuration window_</span> allows admin to specify reCAPTCHA keys for the server. Follow the [step by step guide](/features/#configuring-recaptcha-keys) to setup a <span class="notransate">_Site key_</span> and a <span class="notranslate">_Secret key_</span>.
 
 Click <span class="notranslate">_Save changes_</span> button on the bottom of the section to save changes.
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -441,7 +441,7 @@ service imunify360-webshield restart
 
 ### Greylist and Captcha
 
-The Greylist (ex. CAPTCHA) is a feature intended to distinguish human from machine input and protect websites from the spam and different types of automated abuse. Imunify360 uses specially designed JavaScript challenge ([reCAPTCHA](https://www.google.com/recaptcha/intro/invisible.html) service was used before the Imunify360 webshield version 1.25).
+The Greylist (ex. CAPTCHA) is a feature intended to distinguish human from machine input and protect websites from the spam and different types of automated abuse.
 
 :::warning Warning
 Please note that the WebShield Captcha is not compatible with aggressive CDN caching modes, like Cloudflare 'cache everything' with 'Edge Cache TTL'. If the Сaptcha page is cached by CDN, a visitor will see the Captcha from CDN cache disregarding it has been passed or not. In order to fix that, either disable the aggressive CDN caching or the Captcha functionality in the Imunify360.


### PR DESCRIPTION
Removed reCaptcha challenge reference, however retained from removing all Captcha content as it could be relevant in the context when updating the content for JS challenge. 