### PR TITLE
DEF-38405: sync Proactive Defence docs with i360 

### DIFF
--- a/docs/config_file_description/README.md
+++ b/docs/config_file_description/README.md
@@ -267,7 +267,11 @@ to request Anti-bot Challenge again</td></tr>
 <tr><td><span class="notranslate">mode: LOG</span></td>
 <td># available modes:<ul><li><span class="notranslate">KILL</span></li><li><span class="notranslate">DISABLED</span></li><li><span class="notranslate">LOG</span> (default)</li></ul></td></tr>
 <tr><td><span class="notranslate">php_immunity: False</span></td>
-<td># enable (<span class="notranslate">True</span>) or disable (<span class="notranslate">False (default)) PHP Immunity </span> (allows to automatically detect & patch vulnerabilities in software at the Proactive Defense level preventing re-infections through the same vulnerability). By enabling this feature, Blamer will be enabled as well and Proactive Defence switched into the KILL mode.</td></tr>
+<td># enable (<span class="notranslate">True</span>) or disable (<span class="notranslate">False</span> (default)) <span class="notranslate">PHP Immunity</span> (allows to automatically detect & patch vulnerabilities in software at the Proactive Defense level preventing re-infections through the same vulnerability). By enabling this feature, Blamer will be enabled as well and Proactive Defence switched into the <span class="notranslate">KILL</span> mode.</td></tr>
+<tr><td><span class="notranslate">jit_compatible_mode: True</span></td>
+<td># For PHP 8.0+, if the key is <strong>omitted</strong> or <span class="notranslate">null</span> in the merged config, the extension enables JIT-compatible mode by default. Set to <span class="notranslate">False</span> to disable it explicitly. When enabled, Proactive Defense uses a hooking path compatible with PHP OPcache JIT.</td></tr>
+<tr><td><span class="notranslate">log_whitelisted: False</span></td>
+<td># enable (<span class="notranslate">True</span>) or disable (<span class="notranslate">False</span> (default)) logging of whitelisted events. When enabled, Proactive Defense will log events even for whitelisted scripts, which can be useful for auditing purposes.</td></tr>
 <tr>
 <th colspan="2" align="left"><span class="notranslate">MALWARE_SCAN_INTENSITY:</span></th>
 </tr>

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -973,13 +973,18 @@ Starting from PHP 8, the interpreter supports `opcache.jit` option to enable jus
 
 When the <span class="notranslate">Proactive Defense</span> extension (or any other PHP extensions that use the hooks to intercept function calls) is enabled, opcache engine disables `opcache.jit` automatically and reports it into the error log. It does not affect the stability and performance of websites running PHP 8 when both `opcache.jit` and the <span class="notranslate">Proactive Defense</span> module are enabled, but the JIT will be off.
 
-To keep `opcache.jit` forcibly enabled and keep the <span class="notranslate">Proactive Defense</span> module enabled, one needs to add the following config option:
+To keep `opcache.jit` forcibly enabled and keep the <span class="notranslate">Proactive Defense</span> module enabled, set <span class="notranslate">jit_compatible_mode</span> to <span class="notranslate">True</span> under the <span class="notranslate">PROACTIVE_DEFENCE</span> section in the Imunify360 configuration file (merged config), for example:
 
-```
-jit_compatible_mode=on
+```yaml
+PROACTIVE_DEFENCE:
+  jit_compatible_mode: True
 ```
 
-in the `/usr/share/i360-php-opts/module.ini` file.
+The merged config is typically at <span class="notranslate">/etc/sysconfig/imunify360/imunify360-merged.config</span> (or the non-privileged variant when used). See also [Config file description](/config_file_description/) for the full list of <span class="notranslate">PROACTIVE_DEFENCE</span> options.
+
+::: tip Note
+The PHP extension applies <span class="notranslate">jit_compatible_mode</span> from the merged Imunify360 YAML configuration (not from <span class="notranslate">module.ini</span>). Older documentation referred to <span class="notranslate">module.ini</span>; use <span class="notranslate">PROACTIVE_DEFENCE.jit_compatible_mode</span> in the merged config as shown above.
+:::
 
 
 ## Reputation Management


### PR DESCRIPTION
sync Proactive Defence docs with i360 (YAML, JIT mode defaults)

- Document PROACTIVE_DEFENCE.jit_compatible_mode in merged YAML; PHP 8+ defaults to enabled when key omitted or null.
- Fix opcache.jit section: merged config instead of module.ini; add tip for legacy docs.
- Add log_whitelisted row; tidy php_immunity formatting.

Made-with: Cursor