### PR TITLE
Add Ubuntu 26.04 support, catch up u22 + u24 in upgrade & dashboard s…

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1646,6 +1646,8 @@ Read [CXS integration](/ids_integration/#cxs-integration) documentation carefull
   | Ubuntu 18.04 / Debian 10 |      ✓      |      ✓       |          x          |
   | Ubuntu 20.04             |      ✓      |      ✓       |          x          |
   | Ubuntu 22.04             |      ✓      |      ✓       |          x          |
+  | Ubuntu 24.04             |      ✓      |      ✓       |          x          |
+  | Ubuntu 26.04             |      ✓      |      ✓       |          x          |
   | Debian 11                |      ✓      |      ✓       |          x          |
   | Debian 12                |      ✓      |      ✓       |          x          |
   | Debian 13                |      ✓      |      ✓       |          x          |

--- a/docs/imunifyav/README.md
+++ b/docs/imunifyav/README.md
@@ -52,7 +52,7 @@ ImunifyAV provides malware scanning features for cPanel, Plesk and DirectAdmin c
 
 * <span class="notranslate">CentOS/RHEL</span> 7, 8, 9
 * <span class="notranslate">CloudLinux</span> OS 7, 8, 9
-* <span class="notranslate">Ubuntu</span> 16.04 (LTS only), 18.04, 20.04 (LTS), 22.04 (cPanel, Plesk, DirectAdmin, and standalone), and 24.04
+* <span class="notranslate">Ubuntu</span> 16.04 (LTS only), 18.04, 20.04 (LTS), 22.04 (cPanel, Plesk, DirectAdmin, and standalone), 24.04, and 26.04 (standalone only)
 * <span class="notranslate">Debian</span> 9 (up to Imunify v6.11 (including)), 10 (requires buster-backports), 11, 12 and 13 (Plesk, DirectAdmin, and Stand-alone)
 * <span class="notranslate">AlmaLinux</span> 8, 9, 10
 * <span class="notranslate">Rocky Linux</span> 8, 9 (cPanel, Plesk, and standalone)
@@ -229,6 +229,30 @@ To upgrade ImunifyAV **beta** on Ubuntu 20.04, run the following command:
 
 ```
 echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/20.04/ focal main'  > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify-antivirus
+```
+
+To upgrade ImunifyAV **beta** on Ubuntu 22.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/22.04/ jammy main' > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify-antivirus
+```
+
+To upgrade ImunifyAV **beta** on Ubuntu 24.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/24.04/ noble main' > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify-antivirus
+```
+
+To upgrade ImunifyAV **beta** on Ubuntu 26.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/26.04/ resolute main' > /etc/apt/sources.list.d/imunify360-testing.list
 apt-get update
 apt-get install --only-upgrade imunify-antivirus
 ```

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -8,7 +8,7 @@
 
 * <span class="notranslate">CentOS/RHEL</span> 7, 8, 9
 * <span class="notranslate">CloudLinux</span> OS 7, 8, 9
-* <span class="notranslate">Ubuntu</span> 16.04 (LTS only), 18.04, 20.04 (LTS), 22.04 (cPanel, Plesk, DirectAdmin, and standalone), and 24.04
+* <span class="notranslate">Ubuntu</span> 16.04 (LTS only), 18.04, 20.04 (LTS), 22.04 (cPanel, Plesk, DirectAdmin, and standalone), 24.04, and 26.04 (standalone only)
 * <span class="notranslate">Debian</span> 9 (up to Imunify v6.11 (including)), 10 (requires buster-backports), 11, 12 & 13 (Plesk, DirectAdmin, and stand-alone)
 * <span class="notranslate">AlmaLinux</span> 8, 9, 10
 * <span class="notranslate">Rocky Linux</span> 8, 9 (cPanel, Plesk, and standalone)

--- a/docs/update/README.md
+++ b/docs/update/README.md
@@ -50,6 +50,30 @@ apt-get update
 apt-get install --only-upgrade imunify360-firewall
 ```
 
+To upgrade Imunify360 on Ubuntu 22.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/22.04/ jammy main' > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify360-firewall
+```
+
+To upgrade Imunify360 on Ubuntu 24.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/24.04/ noble main' > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify360-firewall
+```
+
+To upgrade Imunify360 on Ubuntu 26.04, run the following command:
+
+```
+echo 'deb https://repo.imunify360.cloudlinux.com/imunify360/ubuntu-testing/26.04/ resolute main' > /etc/apt/sources.list.d/imunify360-testing.list
+apt-get update
+apt-get install --only-upgrade imunify360-firewall
+```
+
 To upgrade Imunify360 on Debian 9 (supported up to Imunify v6.11 (including)), run the following command:
 
 ```


### PR DESCRIPTION
…ections

Imunify360 + ImunifyAV are now released on Ubuntu 26.04 (resolute) — see build mega-11 (https://build.cloudlinux.com/#/build/69f1c45300e2c9c4380fdc7e) and rollout via DEF-42424 / RE-3653 (beta) + RE-3654 (stable).

Customers can install via the standard `i360deploy.sh` flow on Ubuntu 26.04 today; no panel vendor (cPanel, Plesk, DirectAdmin) has shipped 26.04 support yet, so the Ubuntu entries note "(standalone only)".

Changes:

* `docs/installation/README.md` and `docs/imunifyav/README.md` Supported OS lists — append `26.04 (standalone only)` to the Ubuntu bullet.

* `docs/update/README.md` — Beta upgrade instructions Add per-version `apt-get install --only-upgrade imunify360-firewall` blocks for Ubuntu 22.04 (jammy), 24.04 (noble), 26.04 (resolute). These versions were missing from the section despite already being supported in the installation doc.

* `docs/imunifyav/README.md` — Beta upgrade instructions Same catch-up: add 22.04 / 24.04 / 26.04 blocks for `imunify-antivirus`.

* `docs/dashboard/README.md` — Real-time scanning compatibility table Add Ubuntu 24.04 and 26.04 rows. Both inherit the standard-Linux pattern (inotify ✓ / fanotify ✓ / File-change-API x; the latter is CloudLinux-kernel-only).