### PR TITLE
TCR-868: Update docs.imunify360.com SELinux sections — policy…

### DIFF
--- a/docs/imunifyav/README.md
+++ b/docs/imunifyav/README.md
@@ -138,7 +138,11 @@ Where `YOUR_KEY` is your activation key or IPL in case of IP-based license.
 
 ### SELinux support
 
-If SELinux (Security-Enhanced Linux) is enabled on your server, you should install the Imunify360 SELinux policy module. You can check SELinux status by `sestatus` command. Policy is shipped with Imunify360 package and is located in the <span class="notranslate">`/var/imunify360/imunify-antivirus.te`</span>
+:::tip Note
+If you installed ImunifyAV using `imav-deploy.sh` (including via the Plesk extension or the cPanel EasyApache flow), the SELinux policy module is applied automatically — you can skip this section.
+:::
+
+If you installed the RPM package directly (e.g. `yum install imunify-antivirus`) on a server with SELinux enabled, you need to install the ImunifyAV SELinux policy module manually. You can check SELinux status by `sestatus` command. Policy is shipped with the ImunifyAV package and is located in the <span class="notranslate">`/var/imunify360/imunify-antivirus.te`</span>
 
 To apply it, run the following commands:
 

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -129,7 +129,11 @@ imunify360-agent register IPL
 
 ### SELinux support
 
-If SELinux (Security-Enhanced Linux) is enabled on your server, you should install the Imunify360 SELinux policy module. You can check SELinux status by `sestatus` command. Policy is shipped with Imunify360 package and is located in the <span class="notranslate">`/opt/imunify360/venv/share/imunify360/imunify360.te`</span>
+:::tip Note
+If you installed Imunify360 using `i360deploy.sh` (including via the Plesk extension or the cPanel EasyApache flow), the SELinux policy module is applied automatically — you can skip this section.
+:::
+
+If you installed the RPM package directly (e.g. `yum install imunify360-firewall`) on a server with SELinux enabled, you need to install the Imunify360 SELinux policy module manually. You can check SELinux status by `sestatus` command. Policy is shipped with Imunify360 package and is located in the <span class="notranslate">`/opt/imunify360/venv/share/imunify360/imunify360.te`</span>
 
 To apply it, run the following commands:
 


### PR DESCRIPTION
… module now installed automatically by deploy scripts

1) docs/installation/README.md — SELinux support section
- Added a :::tip Note callout telling users who installed via i360deploy.sh (including Plesk extension / cPanel EasyApache) that the SELinux policy module is applied automatically and they can skip the section.
- Reframed the existing manual instructions to clarify they're only needed for direct RPM installs (yum install imunify360-firewall).
- All existing commands and restart instructions are preserved unchanged. 

2) docs/imunifyav/README.md — SELinux support section
- Same pattern: added a :::tip Note for imav-deploy.sh users, reframed the manual steps for direct RPM installs (yum install imunify-antivirus).
- Also fixed product name references (was saying "Imunify360" in a few places — now correctly says "ImunifyAV").
- All existing commands preserved.