### PR TITLE
TCR-882 (docs: Update Nginx and ModSecurity 3 support info in require…

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -43,7 +43,7 @@
 **Supported Web-servers**
 * <span class="notranslate">Apache</span>
 * <span class="notranslate">LiteSpeed</span>
-* <span class="notranslate">Nginx</span> (fully supported in the [<span class="notranslate">Standalone mode</span>](/control_panel_integration/#introduction); for supported control panels – with ModSecurity 3 only for now (except DirectAdmin))
+* <span class="notranslate">Nginx</span> (fully supported in the [<span class="notranslate">Standalone mode</span>](/control_panel_integration/#introduction))
 
 
 ## Installation Instructions


### PR DESCRIPTION
…ments)

## Summary
This PR updates the Imunify360 installation documentation regarding ModSecurity 3 support under the requirements section.

Specifically, it removes the note indicating that Nginx is supported on control panels using ModSecurity 3.

## Context
Based on internal feedback and support ticket #284058, Nginx + ModSecurity 3 is not supported/recommended on control panels (such as Plesk), and there are no current plans to support it. The ruleset is limited and not actively tested for this configuration.

Users who disable Proxy mode under Nginx settings in Plesk bypass Apache (and therefore bypass the ModSecurity 2.9 WAF protection). They should not switch to Nginx with ModSecurity 3 as an alternative; instead, they must keep Proxy mode enabled or use Standalone mode where fully supported.

## Proposed Changes
docs/installation/README.md
Modified the Nginx web-server support description under requirements: diff
- * <span class="notranslate">Nginx</span> (fully supported in the [<span class="notranslate">Standalone mode</span>](/control_panel_integration/#introduction); for supported control panels – with ModSecurity 3 only for now (except DirectAdmin))
+ * <span class="notranslate">Nginx</span> (fully supported in the [<span class="notranslate">Standalone mode</span>](/control_panel_integration/#introduction)