### PR TITLE
Increase chatbot tooltip dismissal duration to 3 days

### DIFF
--- a/docs/.vuepress/components/Chat.vue
+++ b/docs/.vuepress/components/Chat.vue
@@ -87,7 +87,7 @@ export default {
       iframeUrl: "https://chatbot.cloudlinux.com/docs/imunify360",
       windowWidth: 0, // Changed from window.innerWidth to avoid SSR error
       showTooltip: true,
-      tooltipDismissDuration: 2 * 60 * 60 * 1000, // 2 hours in milliseconds
+      tooltipDismissDuration: 3 * 24 * 60 * 60 * 1000, // 3 days in milliseconds
       dynamicBottom: 20, // Default bottom position
       stopFromBottom: 110, // Stop 100px from page bottom
     };


### PR DESCRIPTION
## Summary

The chatbot tooltip reappeared 2 hours after a user dismissed it, which was often enough to read as nagging. This extends the dismissal window to 3 days.

Matches the same change in `cloudlinux-documentation` ([PR #330](https://github.com/cloudlinux/cloudlinux-documentation/pull/330)) and in `tuxcare-documentation`, so all three docs sites use the same window.

## Change

`docs/.vuepress/components/Chat.vue:90`

```diff
-tooltipDismissDuration: 2 * 60 * 60 * 1000, // 2 hours in milliseconds
+tooltipDismissDuration: 3 * 24 * 60 * 60 * 1000, // 3 days in milliseconds
```

`tooltipDismissDuration` is the single constant both readers compare against — the tooltip display check and the `localStorage` expiry check — so this one edit covers both paths.

## Behavioral note

The change applies retroactively. Users who dismissed the tooltip more than 2 hours but less than 3 days ago will now keep it hidden instead of seeing it return, because their existing `imdocs_chatbot_tooltip_dismissed_time` timestamp is re-evaluated against the longer window. No migration or key change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)